### PR TITLE
Fix:  not enough arguments in call to connect

### DIFF
--- a/funcs/ssh_test.go
+++ b/funcs/ssh_test.go
@@ -16,6 +16,10 @@ const (
 	key      = "../server.key"
 )
 
+// Tests the SSH functionality of the package.
+//
+// It requires manual input of the local SSH private key path into the key
+// variable, and the remote address into the ip variable.
 func Test_SSH(t *testing.T) {
 	var cipherList []string
 	session, err := connect(username, password, ip, key, port, cipherList, nil)

--- a/funcs/ssh_test.go
+++ b/funcs/ssh_test.go
@@ -18,7 +18,7 @@ const (
 
 func Test_SSH(t *testing.T) {
 	var cipherList []string
-	session, err := connect(username, password, ip, key, port, cipherList)
+	session, err := connect(username, password, ip, key, port, cipherList, nil)
 	if err != nil {
 		t.Error(err)
 		return


### PR DESCRIPTION
fix #20 
 
- 修复函数调用错误
- 补充测试函数的说明注释

经过我本地 Linux 的测试结果为通过。
